### PR TITLE
Upgrade AzureNative to 1.104.0

### DIFF
--- a/Pulumi.FSharp.AzureNative/Pulumi.FSharp.AzureNative.fsproj
+++ b/Pulumi.FSharp.AzureNative/Pulumi.FSharp.AzureNative.fsproj
@@ -33,19 +33,19 @@
     <Target Name="CustomBeforeBuild" BeforeTargets="Build" Condition="'$(NoRegenerate)'!='true'">
         <ForceRegenerate />
     </Target>
-    
+
     <Import Project="../Pulumi.FSharp.Myriad\build\Pulumi.FSharp.Myriad.InTest.props" />
-    
+
     <ItemGroup>
-        <PackageReference Include="Pulumi.AzureNative" Version="1.82.0" />
+        <PackageReference Include="Pulumi.AzureNative" Version="1.104.0" />
         <PackageReference Include="Pulumi.FSharp" Version="3.43.1" />
         <PackageReference Include="FSharp.Core" />
         <PackageReference Include="Myriad.Sdk" Version="0.8.1" PrivateAssets="All" />
         <!-- This is required only to force build of the plugin -->
         <ProjectReference Include="../Pulumi.FSharp.Myriad\Pulumi.FSharp.Myriad.fsproj" PrivateAssets="All" />
-        
+
         <ProjectReference Include="..\Pulumi.FSharp.Core\Pulumi.FSharp.Core.fsproj" PrivateAssets="All" />
-        
+
         <Compile Include="Myriad.fs" />
 
         <Compile Include="Generated.fs">


### PR DESCRIPTION
This micro-PR upgrades AzureNative to the latest v1 version - 1.104.0

Pulumi has released v2 of that package and recommends using it, but it still better to have the corresponding F# version for the latest v1. I was also thinking how to better approach v2 with F#. 

I see 2 options:
* To create a separate project and call it Pulumi.FSharp.AzureNativeV2
This will allow to maintain both versions separately in case Pulumi releases updates to v1, which is not guaranteed. But it will also introduce more "hacks" in code since Pulumi are using the same name for their package in Nuget.
* To simply update Pulumi.FSharp.AzureNative in place
It will be simple to keep up with Pulumi's releases, however if we have to update v1, it will require a separate branch, I guess.

What are your thoughts?