### PR TITLE
[FIX] Switch to linking files instead of Project Dependency for Azure Native

### DIFF
--- a/Pulumi.FSharp.AzureNative/Pulumi.FSharp.AzureNative.fsproj
+++ b/Pulumi.FSharp.AzureNative/Pulumi.FSharp.AzureNative.fsproj
@@ -43,7 +43,6 @@
         <PackageReference Include="Myriad.Sdk" Version="0.8.1" PrivateAssets="All" />
         <!-- This is required only to force build of the plugin -->
         <ProjectReference Include="../Pulumi.FSharp.Myriad\Pulumi.FSharp.Myriad.fsproj" PrivateAssets="All" />
-        <ProjectReference Include="..\Pulumi.FSharp.AzureNative.Common\Pulumi.FSharp.AzureNative.Common.fsproj" />
 
         <ProjectReference Include="..\Pulumi.FSharp.Core\Pulumi.FSharp.Core.fsproj" PrivateAssets="All" />
 
@@ -52,6 +51,8 @@
         <Compile Include="Generated.fs">
             <MyriadFile>Myriad.fs</MyriadFile>
         </Compile>
+        <Compile Include="../Pulumi.FSharp.AzureNative.Common/Locations.fs" Link="Locations.fs" />
+        <Compile Include="../Pulumi.FSharp.AzureNative.Common/NamingConventions.fs" Link="NamingConventions.fs" />
 
         <None Include="myriad.toml" />
         <PackageReference Update="FSharp.Core" Version="6.0.6" />

--- a/Pulumi.FSharp.AzureNativeV2/Pulumi.FSharp.AzureNativeV2.fsproj
+++ b/Pulumi.FSharp.AzureNativeV2/Pulumi.FSharp.AzureNativeV2.fsproj
@@ -49,10 +49,11 @@
         <Compile Include="Generated.fs">
             <MyriadFile>Myriad.fs</MyriadFile>
         </Compile>
+        <Compile Include="../Pulumi.FSharp.AzureNative.Common/Locations.fs" Link="Locations.fs" />
+        <Compile Include="../Pulumi.FSharp.AzureNative.Common/NamingConventions.fs" Link="NamingConventions.fs" />
 
         <None Include="myriad.toml" />
         <PackageReference Update="FSharp.Core" Version="6.0.6" />
-        <ProjectReference Include="..\Pulumi.FSharp.AzureNative.Common\Pulumi.FSharp.AzureNative.Common.fsproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
It turned out that `dotnet pack` doesn't include referenced projects in the final nuget package and there is no easy way to do that, it seems.

This PR switched to linking the files for both AzureNative and AzureNativeV2 instead of referencing the Common project. It is a quick fix to keep the code shared, not duplicated. But we might think of a better solution.

Anyway, the currently published `Pulumi.FSharp.AzureNativeV2` v. 2.15.0.1 is broken and should be removed from the Nuget feed.