### PR TITLE
Override Pulumi package name for AzureNativeV2

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -206,8 +206,14 @@ Target.create "Pack" (fun _ ->
             Int32.Parse |>
             (+)1
             
+        let pulumiPackageName =
+            Map.empty |>
+            Map.add "AzureNativeV2" "AzureNative" |>
+            Map.tryFind provider |>
+            Option.defaultValue provider
+            
         let xPath =
-            sprintf "/Project/ItemGroup/PackageReference[@Include='Pulumi.%s']" provider
+            sprintf "/Project/ItemGroup/PackageReference[@Include='Pulumi.%s']" pulumiPackageName
             
         let projectFile =
             getProjectFiles provider |>


### PR DESCRIPTION
Since we created a new project for Azure Native V2, now the names between FSharp project and the original Pulumi package differ.

This PR introduces an override in the `Pack` target to reference the correct Pulumi package.