### PR TITLE
Provider CE

### DIFF
--- a/Pulumi.FSharp.Myriad/Modules.fs
+++ b/Pulumi.FSharp.Myriad/Modules.fs
@@ -20,8 +20,12 @@ let rec createModule name openNamespace types =
                         ])
     | Some [| name |] -> let openNamespaces =
                             match name, String.split '.' openNamespace |> List.ofArray with
-                            | "Inputs", "Kubernetes" :: _    -> []
-                            | name    , "Kubernetes" :: tail ->
+                            // Kubernetes is the only provider, which overrides empty namespace with "Provider"
+                            | "Inputs", [ "Kubernetes"; "Provider" ] -> 
+                                [ Module.open'("Pulumi.Kubernetes.Types.Inputs.Provider") ]
+                            | "Inputs", "Kubernetes" :: _            ->
+                                []
+                            | name    , "Kubernetes" :: tail         ->
                                 let sub = tail |> String.concat "."
                                 let mn types = Module.open'("Pulumi." + "Kubernetes" + types + sub + "." + name)
                                 [ mn ".Types.Inputs."
@@ -295,20 +299,20 @@ let createTypes (schema : JsonValue) =
                                                    | true  -> refTypes
                                                    | false -> allTypes[refType] |>
                                                               getAllNestedTypes (refType :: refTypes)))
-
+        
     let pulumiProviderName =
         schema["name"].AsString()
-
+    
     let resourcesJson =
         schema["resources"].Properties() |>
         // Faking Provider to be in the root namespace
-        Array.append [| $"{pulumiProviderName}:index/Provider:Provider", schema["provider"] |]
-
+        Array.append [| $"{pulumiProviderName}:index:Provider", schema["provider"] |]
+        
     let allNestedTypes =
         resourcesJson |>
         Array.map (snd >> getAllNestedTypes []) |>
-        List.concat
-
+        List.concat        
+    
     let inline typedMatches jsonsArray (regex : ^a) builderType filter =
         let getTypedMatch type' = (^a : (member TypedMatch : string -> 'b) (regex, type'))
         
@@ -474,6 +478,12 @@ let createTypes (schema : JsonValue) =
         
         let openNamespace =
             resourceProviderNamespace |>
+            Option.orElseWith (fun () ->
+                // If resourceProviderNamespace is None, it means "index"
+                // Kubernetes is the only provider which overrides empty namespace with "Provider"
+                match pulumiProviderName with
+                | "kubernetes" -> namespaces[""]
+                | _            -> None) |>
             Option.map (fun rpn -> $"{cloudProviderNamespace}.{rpn}") |>
             Option.defaultValue cloudProviderNamespace
         

--- a/Pulumi.FSharp.Myriad/Modules.fs
+++ b/Pulumi.FSharp.Myriad/Modules.fs
@@ -295,18 +295,20 @@ let createTypes (schema : JsonValue) =
                                                    | true  -> refTypes
                                                    | false -> allTypes[refType] |>
                                                               getAllNestedTypes (refType :: refTypes)))
-        
+
+    let pulumiProviderName =
+        schema["name"].AsString()
+
     let resourcesJson =
-        schema["resources"].Properties()
-        
+        schema["resources"].Properties() |>
+        // Faking Provider to be in the root namespace
+        Array.append [| $"{pulumiProviderName}:index/Provider:Provider", schema["provider"] |]
+
     let allNestedTypes =
         resourcesJson |>
         Array.map (snd >> getAllNestedTypes []) |>
-        List.concat        
-    
-    let pulumiProviderName =
-        schema["name"].AsString()
-    
+        List.concat
+
     let inline typedMatches jsonsArray (regex : ^a) builderType filter =
         let getTypedMatch type' = (^a : (member TypedMatch : string -> 'b) (regex, type'))
         


### PR DESCRIPTION
Currently there is no CE generated for the Provider resource, even though it is present in schema.json. However, it is placed in the root of the JSON, not in the `resources` property.

This PR simply adds `provider` to the `resources`. See the first commit.

BUT! As usual, Kubernetes is special. I checked all Pulumi schemas (more than a hundred) and Kubernetes is the only provider, which has a mapping of an empty namespace to `Provider`:
```json
{
    "language": {
        "csharp": {
            "namespaces": {
                "": "Provider"
            }
        }
    }
}
```

The `Provider` type itself is placed under the main `Pulumi.Kubernetes` namespace, however, it has properties of types `HelmReleaseSettingsArgs` and `KubeClientSettingsArgs`. They are placed under `index` namespace in `schema.json`, but under `Pulumi.Kubernetes.Types.Inputs.Provider` in the NuGet package. Hence the second commit.

One more thing to note. The CEs for the two mentioned above Args are generated under `Pulumi.FSharp.Kubernetes.Inputs` namespace. It seems, having them under `Pulumi.FSharp.Kubernetes.Provider.Inputs` would require quite significant changes. But maybe you have an idea, how to make it easier.