### PR TITLE
CustomResourceOptions CE

### DIFF
--- a/Pulumi.FSharp.Core/CustomResourceOptions.fs
+++ b/Pulumi.FSharp.Core/CustomResourceOptions.fs
@@ -1,0 +1,277 @@
+﻿module Pulumi.FSharp.Core.CustomResourceOptions
+
+open System
+open Pulumi
+open Pulumi.FSharp
+
+type CustomTimeoutsBuilder() =
+    member _.Yield(_: unit) = [ id ]
+
+    member _.Run(opts) =
+        List.fold (fun opts f -> f opts) (CustomTimeouts()) opts
+
+    member this.Combine(lOpts, rOpts) = lOpts @ rOpts
+    member this.For(opts, delayedOpts) = this.Combine(opts, delayedOpts ())
+    member _.Delay(f) = f ()
+    member _.Zero _ = ()
+    
+    /// The optional create timeout.
+    [<CustomOperation("create")>]
+    member _.Create(opts, value) =
+        (fun (opts: CustomTimeouts) ->
+            opts.Create <- Nullable value
+            opts) :: opts
+
+    /// The optional update timeout.
+    [<CustomOperation("update")>]
+    member _.Update(opts, value) =
+        (fun (opts: CustomTimeouts) ->
+            opts.Update <- Nullable value
+            opts) :: opts
+
+    /// The optional delete timeout.
+    [<CustomOperation("delete")>]
+    member _.Delete(opts, value) =
+        (fun (opts: CustomTimeouts) ->
+            opts.Delete <- Nullable value
+            opts) :: opts
+
+let customTimeouts = CustomTimeoutsBuilder()
+            
+type CustomResourceOptionsBuilder() =
+    member _.Yield(_: unit) = [ id ]
+
+    member _.Run(opts) =
+        List.fold (fun opts f -> f opts) (CustomResourceOptions()) opts
+
+    member this.Combine(lOpts, rOpts) = lOpts @ rOpts
+    member this.For(opts, delayedOpts) = this.Combine(opts, delayedOpts ())
+    member _.Delay(f) = f ()
+    member _.Zero _ = ()
+
+    /// When set to <c>true</c>, indicates that this resource should be deleted before its
+    /// replacement is created when replacement is necessary.
+    [<CustomOperation("deleteBeforeReplace")>]
+    member _.DeleteBeforeReplace(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.DeleteBeforeReplace <- Nullable value
+            opts) :: opts
+
+    /// The names of outputs for this resource that should be treated as secrets. This augments
+    /// the list that the resource provider and pulumi engine already determine based on inputs
+    /// to your resource. It can be used to mark certain outputs as a secrets on a per resource
+    /// basis.
+    [<CustomOperation("additionalSecretOutputs")>]
+    member _.AdditionalSecretOutputs(opts, value : #seq<_>) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.AdditionalSecretOutputs <- ResizeArray value
+            opts) :: opts
+
+    /// The names of outputs for this resource that should be treated as secrets. This augments
+    /// the list that the resource provider and pulumi engine already determine based on inputs
+    /// to your resource. It can be used to mark certain outputs as a secrets on a per resource
+    /// basis.
+    member _.AdditionalSecretOutputs(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.AdditionalSecretOutputs <- ResizeArray [ value ]
+            opts) :: opts
+
+    /// When provided with a resource ID, import indicates that this resource's provider should
+    /// import its state from the cloud resource with the given ID.The inputs to the resource's
+    /// constructor must align with the resource's current state.Once a resource has been
+    /// imported, the import property must be removed from the resource's options.
+    [<CustomOperation("importId")>]
+    member _.ImportId(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.ImportId <- value
+            opts) :: opts
+
+    /// An optional existing ID to load, rather than create.
+    [<CustomOperation("id")>]
+    member _.Id(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.Id <- input value
+            opts) :: opts
+
+    /// An optional existing ID to load, rather than create.
+    member _.Id(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.Id <- io value
+            opts) :: opts
+
+    /// An optional parent resource to which this resource belongs.
+    [<CustomOperation("parent")>]
+    member _.Parent(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+             opts.Parent <- value
+             opts) :: opts
+
+    /// Optional additional explicit dependencies on other resources.
+    [<CustomOperation("dependsOn")>]
+    member _.DependsOn(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.DependsOn <- inputList value
+            opts) :: opts
+
+    /// Optional additional explicit dependencies on other resources.
+    member _.DependsOn(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.DependsOn <- inputList [ input value ]
+            opts) :: opts
+
+    /// Optional additional explicit dependencies on other resources.
+    member _.DependsOn(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.DependsOn <- inputList [ io value ]
+            opts) :: opts
+
+    /// Optional additional explicit dependencies on other resources.
+    member _.DependsOn(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.DependsOn <- inputList (Seq.map input value)
+            opts) :: opts
+
+    /// Optional additional explicit dependencies on other resources.
+    member _.DependsOn(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.DependsOn <- inputList (Seq.map io value)
+            opts) :: opts
+
+    /// When set to true, protect ensures this resource cannot be deleted.
+    [<CustomOperation("protect")>]
+    member _.Protect(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.Protect <- Nullable value
+            opts) :: opts
+
+    /// Ignore changes to any of the specified properties.
+    [<CustomOperation("ignoreChanges")>]
+    member _.IgnoreChanges(opts, value : #seq<_>) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.IgnoreChanges <- ResizeArray value
+            opts) :: opts
+
+    /// Ignore changes to any of the specified properties.
+    member _.IgnoreChanges(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.IgnoreChanges <- ResizeArray [ value ]
+            opts) :: opts
+
+    /// An optional version, corresponding to the version of the provider plugin that should be
+    /// used when operating on this resource. This version overrides the version information
+    /// inferred from the current package and should rarely be used.
+    [<CustomOperation("version")>]
+    member _.Version(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.Version <- value
+            opts) :: opts
+
+    /// An optional provider to use for this resource's CRUD operations. If no provider is
+    /// supplied, the default provider for the resource's package will be used. The default
+    /// provider is pulled from the parent's provider bag (see also
+    /// ComponentResourceOptions.providers).
+    ///
+    /// If this is a <see cref="ComponentResourceOptions"/> do not provide both <see
+    /// cref="Provider"/> and <see cref="ComponentResourceOptions.Providers"/>.
+    [<CustomOperation("provider")>]
+    member _.Provider(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.Provider <- value
+            opts) :: opts
+
+    member _.Yield(value) =
+        [fun (opts: CustomResourceOptions) ->
+            opts.CustomTimeouts <- value
+            opts]
+
+    /// Optional list of transformations to apply to this resource during construction.The
+    /// transformations are applied in order, and are applied prior to transformation applied to
+    /// parents walking from the resource up to the stack.
+    [<CustomOperation("resourceTransformations")>]
+    member _.ResourceTransformations(opts, value : #seq<_>) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.ResourceTransformations <- ResizeArray value
+            opts) :: opts
+            
+    /// Optional list of transformations to apply to this resource during construction.The
+    /// transformations are applied in order, and are applied prior to transformation applied to
+    /// parents walking from the resource up to the stack.
+    member _.ResourceTransformations(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.ResourceTransformations <- ResizeArray [ value ]
+            opts) :: opts
+
+    /// An optional list of aliases to treat this resource as matching.
+    [<CustomOperation("aliases")>]
+    member _.Aliases(opts, value : #seq<_>) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.Aliases <- ResizeArray value
+            opts) :: opts
+
+    /// An optional list of aliases to treat this resource as matching.
+    member _.Aliases(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.Aliases <- ResizeArray [ input value ]
+            opts) :: opts
+
+    /// An optional list of aliases to treat this resource as matching.
+    member _.Aliases(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.Aliases <- ResizeArray [ io value ]
+            opts) :: opts
+
+    /// An optional list of aliases to treat this resource as matching.
+    member _.Aliases(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.Aliases <- ResizeArray (Seq.map input value)
+            opts) :: opts
+
+    /// An optional list of aliases to treat this resource as matching.
+    member _.Aliases(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.Aliases <- ResizeArray (Seq.map io value)
+            opts) :: opts
+
+    /// The URN of a previously-registered resource of this type to read from the engine.
+    [<CustomOperation("urn")>]
+    member _.Urn(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.Urn <- value
+            opts) :: opts
+
+    /// Changes to any of these property paths will force a replacement.  If this list
+    /// includes `"*"`, changes to any properties will force a replacement.  Initialization
+    /// errors from previous deployments will require replacement instead of update only if
+    /// `"*"` is passed.
+    [<CustomOperation("replaceOnChanges")>]
+    member _.ReplaceOnChanges(opts, value : #seq<_>) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.ReplaceOnChanges <- ResizeArray value
+            opts) :: opts
+
+    /// Changes to any of these property paths will force a replacement.  If this list
+    /// includes `"*"`, changes to any properties will force a replacement.  Initialization
+    /// errors from previous deployments will require replacement instead of update only if
+    /// `"*"` is passed.
+    member _.ReplaceOnChanges(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.ReplaceOnChanges <- ResizeArray [ value ]
+            opts) :: opts
+
+    /// An optional URL, corresponding to the url from which the provider plugin that should be
+    /// used when operating on this resource is downloaded from. This URL overrides the download URL
+    /// inferred from the current package and should rarely be used.
+    [<CustomOperation("pluginDownloadURL")>]
+    member _.PluginDownloadURL(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.PluginDownloadURL <- value
+            opts) :: opts
+
+    /// If set to True, the providers Delete method will not be called for this resource.
+    [<CustomOperation("retainOnDelete")>]
+    member _.RetainOnDelete(opts, value) =
+        (fun (opts: CustomResourceOptions) ->
+            opts.RetainOnDelete <- Nullable value
+            opts) :: opts
+
+let customResourceOptions = CustomResourceOptionsBuilder()

--- a/Pulumi.FSharp.Core/CustomResourceOptions.fs
+++ b/Pulumi.FSharp.Core/CustomResourceOptions.fs
@@ -1,4 +1,4 @@
-﻿module Pulumi.FSharp.Core.CustomResourceOptions
+﻿module Pulumi.FSharp.Core
 
 open System
 open Pulumi

--- a/Pulumi.FSharp.Core/Pulumi.FSharp.Core.fsproj
+++ b/Pulumi.FSharp.Core/Pulumi.FSharp.Core.fsproj
@@ -27,6 +27,7 @@
         <Compile Include="OutputBuilder.fs" />
         <Compile Include="Config.fs" />
         <Compile Include="Assets.fs" />
+        <Compile Include="CustomResourceOptions.fs" />
         
         <PackageReference Update="FSharp.Core" Version="6.0.6" />
     </ItemGroup>

--- a/Pulumi.FSharp.Myriad/AstHelpers.fs
+++ b/Pulumi.FSharp.Myriad/AstHelpers.fs
@@ -35,6 +35,14 @@ type Pat =
             SynPat.CreateLongIdent(LongIdentWithDots.CreateString(three), [])
         ])
     
+    static member tuple(one, two, three, four) =
+        SynPat.CreateTuple([
+            SynPat.CreateLongIdent(LongIdentWithDots.CreateString(one), [])
+            SynPat.CreateLongIdent(LongIdentWithDots.CreateString(two), [])
+            SynPat.CreateLongIdent(LongIdentWithDots.CreateString(three), [])
+            SynPat.CreateLongIdent(LongIdentWithDots.CreateString(four), [])
+        ])
+    
     static member tuple(left : SynPat, right : SynPat) =
         SynPat.CreateTuple([
             left
@@ -91,6 +99,14 @@ type Expr =
             one
             two
             three
+        ])
+        
+    static member tuple(one, two, three, four) =
+        SynExpr.CreateTuple([
+            one
+            two
+            three
+            four
         ])
         
     /// (a, b, c, ...)

--- a/Pulumi.FSharp.Myriad/IndexModule.fs
+++ b/Pulumi.FSharp.Myriad/IndexModule.fs
@@ -97,23 +97,24 @@ let createModules provider ((indexTypes, qualifiedTypes) : PulumiModule list * P
     let letCombineCrosImplementation = 
         let fromRcd =
             SynPat.CreateLongIdent(LongIdentWithDots.CreateString("_combineCros"),[
-                Pat.paren(Pat.tuple(Pat.paren(Pat.tuple("rName", "rArgs", "rCros")),
-                                    Pat.paren(Pat.tuple("lName", "lArgs", "lCros"))))
+                Pat.paren(Pat.tuple(Pat.paren(Pat.tuple("rName", "rArgs", "rCros", "rCroI")),
+                                    Pat.paren(Pat.tuple("lName", "lArgs", "lCros", "lCroI"))))
             ])
 
-        let matchExpr =
+        let matchExpr argName =
             Expr.paren(
-                Expr.match'(Expr.tuple(Expr.ident("lName"), Expr.ident("rName")), [
+                Expr.match'(Expr.tuple(Expr.ident("l" + argName), Expr.ident("r" + argName)), [
                     Match.clause(Pat.tuple(Pat.null', Pat.null'), Expr.null')
-                    Match.clause(Pat.tuple(Pat.null', Pat.ident("name")), Expr.ident("name"))
-                    Match.clause(Pat.tuple(Pat.ident("name"), Pat.null'), Expr.ident("name"))
-                    Match.clause(Pat.wild, Expr.failwith("Duplicate name"))
+                    Match.clause(Pat.tuple(Pat.null', Pat.ident(argName.ToLower())), Expr.ident(argName.ToLower()))
+                    Match.clause(Pat.tuple(Pat.ident(argName.ToLower()), Pat.null'), Expr.ident(argName.ToLower()))
+                    Match.clause(Pat.wild, Expr.failwith("Duplicate " + argName))
                 ]))
 
         let combineExpr =
-            Expr.tuple(matchExpr,
+            Expr.tuple(matchExpr "Name",
                        Expr.paren(Expr.app("List.concat", (Expr.list [ "lArgs"; "rArgs" ]))),
-                       Expr.paren(Expr.app("List.concat", (Expr.list [ "lCros"; "rCros" ]))))
+                       Expr.paren(Expr.app("List.concat", (Expr.list [ "lCros"; "rCros" ]))),
+                       matchExpr "CroI")
             
         let expr =
             combineExpr

--- a/Pulumi.FSharp.Myriad/Operations.fs
+++ b/Pulumi.FSharp.Myriad/Operations.fs
@@ -25,6 +25,9 @@ let private argsPattern =
 let private crosPattern =
     createPattern "cros" []
 
+let private croIPattern =
+    createPattern "croI" []
+
 let private nPattern =
     createPattern "n" []
 
@@ -45,12 +48,16 @@ let argsTuple' isResource nameVarName withParen =
     
     createTuple [ nvn
                   argsPattern
-                  if isResource then crosPattern ] withParen
+                  if isResource
+                  then
+                      crosPattern
+                      croIPattern ] withParen
 
 let argsTupleResource withParen =
     createTuple [ namePattern
                   argsPattern
-                  crosPattern ] withParen
+                  crosPattern
+                  croIPattern ] withParen
 
 let argsTupleType withParen =
     createTuple [ SynPat.CreateWild
@@ -222,7 +229,7 @@ let private returnTupleCache argsType pType opName setRight =
     
     match pType.IsResource with    
     | false -> Expr.tuple(Expr.ident("n"), cons)
-    | true  -> Expr.tuple(Expr.ident("name"), cons, Expr.ident("cros"))
+    | true  -> Expr.tuple(Expr.ident("name"), cons, Expr.ident("cros"), Expr.ident("croI"))
 
 let createOperationsFor' argsType pType =
     let setRights, argType =
@@ -321,6 +328,7 @@ let croOperation operationName description argumentName (setAssignmentExpression
     let expression =
         Expr.tuple(Expr.ident("name"),
                    Expr.ident("args"),
-                   updateCrosExpression setAssignmentExpression)
+                   updateCrosExpression setAssignmentExpression,
+                   Expr.ident("croI"))
     
     createMember'' doc operationName patterns attributes expression

--- a/Pulumi.FSharp.Myriad/Yield.fs
+++ b/Pulumi.FSharp.Myriad/Yield.fs
@@ -5,12 +5,13 @@ open FSharp.Compiler.Syntax
 open Myriad.Core.Ast
 open Myriad.Core.AstExtensions
 
-let createYield' isType (arg : SynPat) (args : SynExpr) (cros : SynExpr) =
+let createYield' isType (arg : SynPat) (args : SynExpr) (cros : SynExpr) (croI : SynExpr) =
     [
         SynExpr.CreateNull
         args
         if not isType then
             cros
+            croI
     ] |>
     SynExpr.CreateTuple |>
     createMember "Yield" arg []


### PR DESCRIPTION
This PR adds:
* `CustomResourceOptions` CE in `Pulumi.FSharp.Core`
This is just a hard-coded CE for the Pulumi type (also includes CE for `CustomTimeouts`)
* `Yield` operation in the resources CEs

I've managed to avoid breaking changes and kept the existing `dependsOn` operation, which will overwrite that property on the passed `customResourceOptions`. I also added a deprecation notice in the comments.

Here is an example of a generated code:
```fsharp
namespace Pulumi.FSharp

open Pulumi.FSharp
open Pulumi

module Docker =
    open Pulumi.Docker

    let _combine ((rName, rArgs), (lName, lArgs)) =
        (match lName, rName with
         | null, null -> null
         | null, name -> name
         | name, null -> name
         | _ -> failwith "Duplicate name"),
        (List.concat [ lArgs; rArgs ])

    let _combineCros ((rName, rArgs, rCros, rCroI), (lName, lArgs, lCros, lCroI)) =
        (match lName, rName with
         | null, null -> null
         | null, name -> name
         | name, null -> name
         | _ -> failwith "DuplicateName"),
        (List.concat [ lArgs; rArgs ]),
        (List.concat [ lCros; rCros ]),
        (match lCroI, rCroI with
         | null, null -> null
         | null, croi -> croi
         | croi, null -> croi
         | _ -> failwith "DuplicateCroI")

    type ImageBuilder() =


            member _.Yield(_: unit) = null, [ id ], [ id ], null

            member _.Run(name, args, cros, croI) =
                Image(
                    name,
                    List.fold (fun args f -> f args) (ImageArgs()) args,
                    List.fold
                        (fun cros f -> f cros)
                        (match croI with
                         | null -> CustomResourceOptions()
                         | croI -> croI)
                        cros
                )

            member this.Combine(args) = _combineCros args
            member this.For(args, delayedArgs) = this.Combine(args, delayedArgs ())
            member _.Delay(f) = f ()
            member _.Zero _ = ()

            ///Pulumi logical resource name
            [<CustomOperation("name")>]
            member _.Name((_, args, cros, croI), newName) = newName, args, cros, croI

            member _.Yield(arg) =
                null,
                [ (let func (args: ImageArgs) =
                      args.Build <- input arg
                      args

                   ()
                   func) ],
                [ id ],
                null

            ///The image name, of the format repository[:tag], e.g. `docker.io/username/demo-image:v1`.
            ///This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, or the local image ID, please use `repoDigest`.
            [<CustomOperation("imageName")>]
            member _.ImageName((name, args, cros, croI), imageName) =
                name,
                List.Cons(
                    (fun (args: ImageArgs) ->
                        args.ImageName <- input imageName
                        args),
                    args
                ),
                cros,
                croI

            ///The image name, of the format repository[:tag], e.g. `docker.io/username/demo-image:v1`.
            ///This reference is not unique to each build and push.For the unique manifest SHA of a pushed docker image, or the local image ID, please use `repoDigest`.
            member _.ImageName((name, args, cros, croI), imageName) =
                name,
                List.Cons(
                    (fun (args: ImageArgs) ->
                        args.ImageName <- io imageName
                        args),
                    args
                ),
                cros,
                croI

            member _.Yield(arg) =
                null,
                [ (let func (args: ImageArgs) =
                      args.Registry <- input arg
                      args

                   ()
                   func) ],
                [ id ],
                null

            ///A flag to skip a registry push.
            [<CustomOperation("skipPush")>]
            member _.SkipPush((name, args, cros, croI), skipPush) =
                name,
                List.Cons(
                    (fun (args: ImageArgs) ->
                        args.SkipPush <- input skipPush
                        args),
                    args
                ),
                cros,
                croI

            ///A flag to skip a registry push.
            member _.SkipPush((name, args, cros, croI), skipPush) =
                name,
                List.Cons(
                    (fun (args: ImageArgs) ->
                        args.SkipPush <- io skipPush
                        args),
                    args
                ),
                cros,
                croI

            ///Obsolete. Use customResourceOptions nested CE. Ensure this resource gets created after its dependency
            [<CustomOperation("dependsOn")>]
            member _.DependsOn((name, args, cros, croI), dependency) =
                name,
                args,
                List.Cons(
                    (fun (cros: CustomResourceOptions) ->
                        cros.DependsOn <- inputList [ input dependency ]
                        cros),
                    cros
                ),
                croI

            ///Obsolete. Use customResourceOptions nested CE. Ensure this resource gets created after its dependency
            member _.DependsOn((name, args, cros, croI), dependency) =
                name,
                args,
                List.Cons(
                    (fun (cros: CustomResourceOptions) ->
                        cros.DependsOn <- inputList (Seq.map input dependency)
                        cros),
                    cros
                ),
                croI

            member _.Yield(croI: CustomResourceOptions) = null, [ id ], [ id ], croI

    ///`Image` builds a Docker image and pushes it Docker and OCI compatible registries.
    ///
    ///*** Operations ***
    ///
    /// - imageName
    ///
    /// - skipPush
    ///
    ///
    ///
    ///*** Nested computational expressions ***
    ///
    /// - dockerBuild
    ///
    /// - registry
    let image = ImageBuilder()
```