### PR TITLE
Upgrade Pulumi.Command to 0.9.2

### DIFF
--- a/Pulumi.FSharp.Command/Pulumi.FSharp.Command.fsproj
+++ b/Pulumi.FSharp.Command/Pulumi.FSharp.Command.fsproj
@@ -37,7 +37,7 @@
     <Import Project="../Pulumi.FSharp.Myriad\build\Pulumi.FSharp.Myriad.InTest.props" />
     
     <ItemGroup>
-        <PackageReference Include="Pulumi.Command" Version="0.5.2" />
+        <PackageReference Include="Pulumi.Command" Version="0.9.2" />
         <PackageReference Include="Pulumi.FSharp" Version="3.43.1" />
         <PackageReference Include="FSharp.Core" />
         <PackageReference Include="Myriad.Sdk" Version="0.8.1" PrivateAssets="All" />


### PR DESCRIPTION
I noticed that the build fails for Pulumi.Command for version 0.5.2 due to the missing `provider` field in the shema. In version 0.9.2 it exists. So this should fix the build. 
Please note the `provider` field is an empty object for this package, so it still doesn't output any CE for `Provider`.