### PR TITLE
Allow digits in Pulumi provider name (e.g auth0)

### DIFF
--- a/Pulumi.FSharp.Myriad/Builder.fs
+++ b/Pulumi.FSharp.Myriad/Builder.fs
@@ -14,7 +14,7 @@ open FSharp.Text.RegexProvider
 // "azure:compute/virtualMachine:VirtualMachine"
 // CloudProvider - Always the same for each schema (azure here)
 type InfoProvider =
-    Regex<"(?<CloudProvider>[a-z-]+):(?<ResourceProviderNamespace>[A-Za-z0-9.]+)(/(?<SubNamespace>\w+))?:(?<ResourceType>\w+)">
+    Regex<"(?<CloudProvider>[a-z0-9-]+):(?<ResourceProviderNamespace>[A-Za-z0-9.]+)(/(?<SubNamespace>\w+))?:(?<ResourceType>\w+)">
 
 let typeInfoProvider =
     InfoProvider(RegexOptions.Compiled)


### PR DESCRIPTION
Some providers, namely Auth0, could not be used with Pulumi.FSharp.Myriad because it tried to match on [a-z-]+